### PR TITLE
Add debian/watch files

### DIFF
--- a/execline/debian/watch
+++ b/execline/debian/watch
@@ -1,0 +1,3 @@
+version=3
+https://github.com/skarnet/execline/releases \
+	/skarnet/execline/archive/v(.+).tar.gz

--- a/s6/debian/watch
+++ b/s6/debian/watch
@@ -1,0 +1,3 @@
+version=3
+https://github.com/skarnet/s6/releases \
+	/skarnet/s6/archive/v(.+).tar.gz

--- a/skalibs/debian/watch
+++ b/skalibs/debian/watch
@@ -1,0 +1,3 @@
+version=3
+https://github.com/skarnet/skalibs/releases \
+	/skarnet/skalibs/archive/v(.+).tar.gz


### PR DESCRIPTION
So, `uscan` requires a page where it can see all the versions, but I can't find such a page on skarnet.org. Instead we can use the GitHub mirrors (which seems reasonable, given that these are official mirrors maintained by the same person).

You can check these by cd-ing into directories and running `uscan --debug --report`. The output looks similar to:

```
[some lines snipped]
uscan debug: matching pattern(s) (?:(?:https://github.com)?\/skarnet\/s6\/releases)?/skarnet/s6/archive/v(.+).tar.gz
-- Found the following matching hrefs:
     /skarnet/s6/archive/v2.2.0.0.tar.gz
     /skarnet/s6/archive/v2.1.6.0.tar.gz
     /skarnet/s6/archive/v2.1.5.0.tar.gz
     /skarnet/s6/archive/v2.1.4.0.tar.gz
     /skarnet/s6/archive/v2.1.3.0.tar.gz
     /skarnet/s6/archive/v2.1.2.0.tar.gz
     /skarnet/s6/archive/v2.1.1.2.tar.gz
     /skarnet/s6/archive/v2.1.1.1.tar.gz
     /skarnet/s6/archive/v2.1.1.0.tar.gz
     /skarnet/s6/archive/v2.1.0.1.tar.gz
Newest version on remote site is 2.2.0.0, local version is 2.0.1.0
 => Newer version available from
    https://github.com/skarnet/s6/archive/v2.2.0.0.tar.gz
-- Scan finished
```
